### PR TITLE
feat: configure Swagger for API documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,12 +17,13 @@
         "@nestjs/microservices": "^11.1.3",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "^11.2.0",
         "bull": "^4.16.5",
-        "dotenv": "^17.0.0",
         "ioredis": "^5.6.1",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -34,9 +35,9 @@
         "@swc/core": "^1.10.7",
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "^22.15.34",
+        "@types/node": "^22.10.7",
         "@types/supertest": "^6.0.2",
-        "eslint": "^9.18.0",
+        "eslint": "^9.30.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.2",
         "globals": "^16.0.0",
@@ -1965,6 +1966,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "license": "MIT"
+    },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
@@ -2703,6 +2710,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/microservices": {
       "version": "11.1.3",
       "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-11.1.3.tgz",
@@ -2890,6 +2917,39 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.0.tgz",
+      "integrity": "sha512-5wolt8GmpNcrQv34tIPUtPoV1EeFbCetm40Ij3+M0FNNnf2RJ3FyWfuQvI8SBlcJyfaounYVTKzKHreFXsUyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.1",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "8.2.0",
+        "swagger-ui-dist": "5.21.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "11.1.3",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.3.tgz",
@@ -3007,6 +3067,13 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -4970,7 +5037,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -6165,18 +6231,6 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.0.0.tgz",
-      "integrity": "sha512-A0BJ5lrpJVSfnMMXjmeO0xUnoxqsBHWCoqqTnGwGYVdnctqXXUEhJOO7LxmgxJon9tEZFGpe0xPRX0h2v3AANQ==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dotenv-expand": {
@@ -8698,7 +8752,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11164,6 +11217,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.21.0.tgz",
+      "integrity": "sha512-E0K3AB6HvQd8yQNSMR7eE5bk+323AUxjtCz/4ZNKiahOlPhPJxqn3UPIGs00cyY/dhrTDJ61L7C/a8u6zhGrZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -28,11 +28,13 @@
     "@nestjs/microservices": "^11.1.3",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.2.0",
     "bull": "^4.16.5",
     "ioredis": "^5.6.1",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -46,7 +48,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.7",
     "@types/supertest": "^6.0.2",
-    "eslint": "^9.18.0",
+    "eslint": "^9.30.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",
     "globals": "^16.0.0",

--- a/src/controllers/auth/auth.controller.ts
+++ b/src/controllers/auth/auth.controller.ts
@@ -1,6 +1,8 @@
 import { ClientProxyService } from '../../service/client-proxy.service';
 import { HttpException } from '../../exceptions/http-exception';
 import { Body, Controller, Post, Res } from '@nestjs/common';
+import { ApiBadRequestResponse, ApiBody, ApiConflictResponse, ApiCreatedResponse, ApiInternalServerErrorResponse, ApiNotFoundResponse, ApiOperation, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { CreateUserDto, LoginUserDto } from '../../dto/auth.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -10,6 +12,12 @@ export class AuthController {
     ) { }
 
     @Post('store')
+    @ApiOperation({ description: 'Save a new user to the database with the provided data.', summary: 'Create a new user.' })
+    @ApiCreatedResponse({ description: 'Created: The request has been fulfilled and resulted in a new resource being created.' })
+    @ApiBadRequestResponse({ description: 'Bad Request: This response means that the server could not understand the request due to invalid syntax or field.' })
+    @ApiConflictResponse({ description: 'Conflict: The request could not be completed due to a conflict with the current state of the resource.' })
+    @ApiInternalServerErrorResponse({ description: 'Internal Server Error: A generic error message, given when no more specific message is suitable.' })
+    @ApiBody({ type: CreateUserDto, description: 'These fields are mandatory for registration: fullName, email and password.' })
     async store(@Body() body, @Res() res) {
         const response = await this._clientProxyService.client.send('auth/store', body).toPromise();
 
@@ -17,6 +25,13 @@ export class AuthController {
     }
 
     @Post('login')
+    @ApiOperation({ description: 'Authenticate the user with email and password, and return a JWT token upon successful login.', summary: 'User login.' })
+    @ApiCreatedResponse({ description: 'Created: The request has been fulfilled and resulted in a new resource being created.' })
+    @ApiBadRequestResponse({ description: 'Bad Request: This response means that the server could not understand the request due to invalid syntax or field.' })
+    @ApiUnauthorizedResponse({ description: 'Unauthorized: Authentication is needed to get the requested response' })
+    @ApiNotFoundResponse({ description: 'Not Found: The requested resource could not be found' })
+    @ApiInternalServerErrorResponse({ description: 'Internal Server Error: A generic error message, given when no more specific message is suitable.' })
+    @ApiBody({ type: LoginUserDto, description: 'These fields are mandatory for registration: email and password.' })
     async login(@Body() body, @Res() res) {
         const response = await this._clientProxyService.client.send('auth/login', body).toPromise();
 

--- a/src/controllers/url-shortener/url-shortener.controller.ts
+++ b/src/controllers/url-shortener/url-shortener.controller.ts
@@ -3,6 +3,8 @@ import { HttpException } from '../../exceptions/http-exception';
 import { Body, Controller, Delete, Get, Param, Post, Put, Query, Req, Res, UseGuards } from '@nestjs/common';
 import { JwtOptionalGuard } from '../../config/jwt-optional.guard';
 import { JwtGuard } from '../../config/jwt-guard.guard';
+import { UrlDto } from '../../dto/url-sortener.dto';
+import { ApiBadRequestResponse, ApiBody, ApiConflictResponse, ApiCreatedResponse, ApiInternalServerErrorResponse, ApiNotFoundResponse, ApiOperation, ApiQuery, ApiUnauthorizedResponse } from '@nestjs/swagger';
 
 @Controller('url-shortener')
 export class UrlShortenerController {
@@ -13,6 +15,13 @@ export class UrlShortenerController {
 
     @Post('store')
     @UseGuards(JwtOptionalGuard)
+    @ApiOperation({ description: 'Save a new original URL to the database to generate its shortened version.', summary: 'Create a new shortened URL.' })
+    @ApiCreatedResponse({ description: 'Created: The request has been fulfilled and resulted in a new resource being created.' })
+    @ApiBadRequestResponse({ description: 'Bad Request: This response means that the server could not understand the request due to invalid syntax or field.' })
+    @ApiConflictResponse({ description: 'Conflict: The request could not be completed due to a conflict with the current state of the resource.' })
+    @ApiNotFoundResponse({ description: 'Not Found: The requested resource could not be found' })
+    @ApiInternalServerErrorResponse({ description: 'Internal Server Error: A generic error message, given when no more specific message is suitable.' })
+    @ApiBody({ type: UrlDto, description: 'These fields are mandatory for registration: url.' })
     async store(@Body() body, @Res() res, @Req() req) {
         const response = await this._clientProxyService.client.send('url-shortener/store', { body, user: req?.user }).toPromise();
 
@@ -21,6 +30,10 @@ export class UrlShortenerController {
 
     @Get('index')
     @UseGuards(JwtOptionalGuard)
+    @ApiOperation({ description: 'Retrieve all URLs stored in the database. If authenticated with a valid token, returns only the URLs belonging to the authenticated user.', summary: 'List URLs.' })
+    @ApiBadRequestResponse({ description: 'Bad Request: This response means that the server could not understand the request due to invalid syntax or field.' })
+    @ApiNotFoundResponse({ description: 'Not Found: The requested resource could not be found' })
+    @ApiInternalServerErrorResponse({ description: 'Internal Server Error: A generic error message, given when no more specific message is suitable.' })
     async login(@Res() res, @Req() req) {
         const response = await this._clientProxyService.client.send('url-shortener/index', { user: req?.user }).toPromise();
 
@@ -28,6 +41,11 @@ export class UrlShortenerController {
     }
 
     @Get('redirect')
+    @ApiOperation({ summary: 'Redirect to original URL', description: 'Redirects to the original URL based on the shortened version passed as a query parameter.', })
+    @ApiBadRequestResponse({ description: 'Bad Request: This response means that the server could not understand the request due to invalid syntax or field.' })
+    @ApiNotFoundResponse({ description: 'Not Found: The requested resource could not be found' })
+    @ApiInternalServerErrorResponse({ description: 'Internal Server Error: Something went wrong during the redirect process.' })
+    @ApiQuery({ name: 'url', type: String, required: true, description: 'The original URL to be redirected from the shortened version.', })
     async redirect(@Query('url') url: string, @Res() res) {
         const response = await this._clientProxyService.client.send('url-shortener/redirect', { url },).toPromise();
 
@@ -36,6 +54,14 @@ export class UrlShortenerController {
 
     @Put('update/:id')
     @UseGuards(JwtGuard)
+    @ApiOperation({ description: 'Update an existing shortened URL by ID. Authentication is required.', summary: 'Update a shortened URL.' })
+    @ApiCreatedResponse({ description: 'Created: The request has been fulfilled and resulted in a new resource being created.' })
+    @ApiBadRequestResponse({ description: 'Bad Request: This response means that the server could not understand the request due to invalid syntax or field.' })
+    @ApiUnauthorizedResponse({ description: 'Unauthorized: Authentication is needed to get the requested response' })
+    @ApiConflictResponse({ description: 'Conflict: The request could not be completed due to a conflict with the current state of the resource.' })
+    @ApiNotFoundResponse({ description: 'Not Found: The requested resource could not be found' })
+    @ApiInternalServerErrorResponse({ description: 'Internal Server Error: A generic error message, given when no more specific message is suitable.' })
+    @ApiBody({ type: UrlDto, description: 'These fields are mandatory for registration: id and url.' })
     async update(@Body() body, @Param('id') id, @Res() res, @Req() req) {
         const response = await this._clientProxyService.client.send('url-shortener/update', { id, body, user: req?.user }).toPromise();
 
@@ -44,6 +70,13 @@ export class UrlShortenerController {
 
     @Delete('delete/:id')
     @UseGuards(JwtGuard)
+    @ApiOperation({ description: 'Logically deletes the shortened URL by marking it as inactive. The record is no longer visible or editable.', summary: 'Deactivate shortened URL.' })
+    @ApiCreatedResponse({ description: 'Created: The request has been fulfilled and resulted in a new resource being created.' })
+    @ApiBadRequestResponse({ description: 'Bad Request: This response means that the server could not understand the request due to invalid syntax or field.' })
+    @ApiUnauthorizedResponse({ description: 'Unauthorized: Authentication is needed to get the requested response' })
+    @ApiNotFoundResponse({ description: 'Not Found: The requested resource could not be found' })
+    @ApiInternalServerErrorResponse({ description: 'Internal Server Error: A generic error message, given when no more specific message is suitable.' })
+    @ApiBody({ description: 'These fields are mandatory for registration: id.' })
     async delete(@Param('id') id, @Res() res, @Req() req) {
         const response = await this._clientProxyService.client.send('url-shortener/delete', { id, user: req?.user }).toPromise();
 

--- a/src/dto/auth.dto.ts
+++ b/src/dto/auth.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class CreateUserDto {
+    @ApiProperty({ description: 'User fullName', required: true, type: String })
+    fullName: string;
+
+    @ApiProperty({ description: 'User email address', required: true, type: String })
+    email: string;
+
+    @ApiProperty({ description: 'User password', required: true, type: String })
+    password: string;
+}
+
+export class LoginUserDto {
+    @ApiProperty({ description: 'User email address', required: true, type: String })
+    email: string;
+
+    @ApiProperty({ description: 'User password', required: true, type: String })
+    password: string;
+}

--- a/src/dto/url-sortener.dto.ts
+++ b/src/dto/url-sortener.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class UrlDto {
+    @ApiProperty({   description: 'Original URL to be shortened', required: true, type: String })
+    url: string;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,18 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const document = SwaggerModule.createDocument(app, new DocumentBuilder()
+    .setTitle('Api Gateway')
+    .setDescription('Api Gateway')
+    .addBearerAuth()
+    .setVersion('1.0')
+    .build());
+
+  SwaggerModule.setup('swagger', app, document);
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();


### PR DESCRIPTION
## ✅ Summary

Add Swagger module for API documentation and enable route `/api/docs`

---

## 🚀 Features

- Swagger module installed and configured
- Added API metadata
- Applied basic decorators like `@ApiBody`, `@ApiOperation`

---

## 🔍 Code Review & Testing

- ✅ Self-reviewed the code for clarity and standards  
- ✅ Manual testing performed via Insomnia  
- ✅ All unit tests passing successfully

---

## 📝 Notes

- No breaking changes introduced  
- No new dependencies added (NestJS Swagger already part of setup)
